### PR TITLE
wip: emitted

### DIFF
--- a/app/TodoItem.ts
+++ b/app/TodoItem.ts
@@ -1,4 +1,4 @@
-import { defineComponent, h, getCurrentInstance } from 'vue'
+import { defineComponent, h } from 'vue'
 
 import { Todo } from './types'
 
@@ -14,12 +14,6 @@ export const TodoItem = defineComponent({
 
 
   setup(props, ctx) {
-    const originalEmit = ctx.emit
-    ctx.emit = (event: string, ...args: unknown[]) => {
-      console.log('Event is', event)
-      return originalEmit.call(getCurrentInstance(), event, ...args)
-    }
-
     return () => {
       return h(
           'div', { className: `todo-item ${props.todo.complete ? 'todo-item-complete' : ''}` }, [

--- a/app/TodoItem.ts
+++ b/app/TodoItem.ts
@@ -1,4 +1,4 @@
-import { defineComponent, h } from 'vue'
+import { defineComponent, h, getCurrentInstance } from 'vue'
 
 import { Todo } from './types'
 
@@ -14,6 +14,12 @@ export const TodoItem = defineComponent({
 
 
   setup(props, ctx) {
+    const originalEmit = ctx.emit
+    ctx.emit = (event: string, ...args: unknown[]) => {
+      console.log('Event is', event)
+      return originalEmit.call(getCurrentInstance(), event, ...args)
+    }
+
     return () => {
       return h(
           'div', { className: `todo-item ${props.todo.complete ? 'todo-item-complete' : ''}` }, [

--- a/framework/mount.ts
+++ b/framework/mount.ts
@@ -46,16 +46,6 @@ export function mount<P>(
 
         return originalEmit.call(getCurrentInstance(), event, ...args)
       }
-
-      if (getCurrentInstance().setupContext) {
-        getCurrentInstance().setupContext.emit = (event: string, ...args: unknown[]) => {
-          events[event]
-            ? events[event] = [...events[event], [...args]]
-            : events[event] = [[...args]]
-
-          return originalEmit.call(getCurrentInstance(), event, ...args)
-        }
-      }
     }
   }
 

--- a/framework/mount.ts
+++ b/framework/mount.ts
@@ -38,7 +38,6 @@ export function mount<P>(
   const events: Record<string, unknown[]> = {}
   const emitMixin = {
     beforeCreate() {
-      getCurrentInstance().sink.events = {}
       const originalEmit = getCurrentInstance().emit
       getCurrentInstance().emit = (event: string, ...args: unknown[]) => {
         events[event] 

--- a/framework/mount.ts
+++ b/framework/mount.ts
@@ -46,6 +46,16 @@ export function mount<P>(
 
         return originalEmit.call(getCurrentInstance(), event, ...args)
       }
+
+      if (getCurrentInstance().setupContext) {
+        getCurrentInstance().setupContext.emit = (event: string, ...args: unknown[]) => {
+          events[event]
+            ? events[event] = [...events[event], [...args]]
+            : events[event] = [[...args]]
+
+          return originalEmit.call(getCurrentInstance(), event, ...args)
+        }
+      }
     }
   }
 

--- a/framework/mount.ts
+++ b/framework/mount.ts
@@ -1,4 +1,4 @@
-import { ComponentPublicInstance, createApp, VNode, defineComponent, h } from 'vue'
+import { ComponentPublicInstance, createApp, VNode, defineComponent, h, getCurrentInstance } from 'vue'
 
 import { Hashmap } from './types'
 import { VueWrapper, createWrapper } from './vue-wrapper'
@@ -35,7 +35,24 @@ export function mount<P>(
     }
   })
 
-  const vm = createApp(Parent(options && options.props)).mount('#app')
+  const events: Record<string, unknown[]> = {}
+  const emitMixin = {
+    beforeCreate() {
+      getCurrentInstance().sink.events = {}
+      const originalEmit = getCurrentInstance().emit
+      getCurrentInstance().emit = (event: string, ...args: unknown[]) => {
+        events[event] 
+          ? events[event] = [...events[event], [...args]]
+          : events[event] = [[...args]]
 
-  return createWrapper(vm)
+        return originalEmit.call(getCurrentInstance(), event, ...args)
+      }
+    }
+  }
+
+  const vm = createApp(Parent(options && options.props))
+  vm.mixin(emitMixin)
+  const app = vm.mount('#app')
+
+  return createWrapper(app, events)
 }

--- a/framework/vue-wrapper.ts
+++ b/framework/vue-wrapper.ts
@@ -1,4 +1,4 @@
-import { ComponentPublicInstance } from 'vue'
+import { ComponentPublicInstance, getCurrentInstance } from 'vue'
 
 import { DOMWrapper } from './dom-wrapper'
 import { WrapperAPI } from './types'
@@ -6,9 +6,11 @@ import { ErrorWrapper } from './error-wrapper'
 
 export class VueWrapper implements WrapperAPI {
   vm: ComponentPublicInstance
+  __emitted: Record<string, unknown[]> = {}
 
-  constructor(vm: ComponentPublicInstance) {
+  constructor(vm: ComponentPublicInstance, events: Record<string, unknown[]>) {
     this.vm = vm
+    this.__emitted = events
   }
 
   classes(): string[] {
@@ -17,6 +19,10 @@ export class VueWrapper implements WrapperAPI {
 
   exists() {
     return true
+  }
+
+  emitted() {
+    return this.__emitted
   }
 
   html() {
@@ -46,6 +52,6 @@ export class VueWrapper implements WrapperAPI {
   }
 }
 
-export function createWrapper(vm: ComponentPublicInstance): VueWrapper {
-  return new VueWrapper(vm)
+export function createWrapper(vm: ComponentPublicInstance, events: Record<string, unknown[]>): VueWrapper {
+  return new VueWrapper(vm, events)
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,8 +11,9 @@ module.exports = {
   ],
   moduleFileExtensions: ['vue', 'js', 'json', 'jsx', 'ts', 'tsx', 'node'],
   moduleNameMapper: {
-    "^vue$": "<rootDir>/node_modules/vue/dist/vue.esm.prod.js"
-  }
+    "^vue$": "<rootDir>/node_modules/vue/dist/vue.esm.js"
+  },
+  setupFiles: ['./tests/setup.js']
 }
 
 

--- a/tests/emit.spec.ts
+++ b/tests/emit.spec.ts
@@ -1,0 +1,44 @@
+import { defineComponent, h } from 'vue'
+
+import { mount } from '../framework'
+
+describe('emitted', () => {
+  it('works with this.$emit', () => {
+    const Component = defineComponent({
+      render() {
+        return h(
+          'div', [
+          h('button', { onClick: () => this.$emit('hello', 'foo', 'bar') })
+        ]
+        )
+      }
+    })
+
+    const wrapper = mount(Component)
+    wrapper.find('button').trigger('click')
+    expect(wrapper.emitted().hello[0]).toEqual(['foo', 'bar'])
+
+    wrapper.find('button').trigger('click')
+    expect(wrapper.emitted().hello[1]).toEqual(['foo', 'bar'])
+  })
+
+  it('works with context.emit', () => {
+    const Component = defineComponent({
+      setup(props, ctx) {
+        return () => 
+          h(
+            'div', [
+            h('button', { onClick: () => ctx.emit('hello', 'foo', 'bar') })
+          ]
+        )
+      }
+    })
+
+    const wrapper = mount(Component)
+    wrapper.find('button').trigger('click')
+    expect(wrapper.emitted().hello[0]).toEqual(['foo', 'bar'])
+
+    wrapper.find('button').trigger('click')
+    expect(wrapper.emitted().hello[1]).toEqual(['foo', 'bar'])
+  })
+})

--- a/tests/emit.spec.ts
+++ b/tests/emit.spec.ts
@@ -22,8 +22,10 @@ describe('emitted', () => {
     expect(wrapper.emitted().hello[1]).toEqual(['foo', 'bar'])
   })
 
-  it('works with context.emit', () => {
+  it.only('works with context.emit', () => {
     const Component = defineComponent({
+      name: 'ContextEmit',
+
       setup(props, ctx) {
         return () => 
           h(

--- a/tests/emit.spec.ts
+++ b/tests/emit.spec.ts
@@ -3,7 +3,7 @@ import { defineComponent, h } from 'vue'
 import { mount } from '../framework'
 
 describe('emitted', () => {
-  it('works with this.$emit', () => {
+  it('captures events emitted via this.$emit', () => {
     const Component = defineComponent({
       render() {
         return h(
@@ -13,8 +13,10 @@ describe('emitted', () => {
         )
       }
     })
-
     const wrapper = mount(Component)
+    expect(wrapper.emitted()).toEqual({})
+    expect(wrapper.emitted().hello).toEqual(undefined)
+
     wrapper.find('button').trigger('click')
     expect(wrapper.emitted().hello[0]).toEqual(['foo', 'bar'])
 
@@ -22,7 +24,10 @@ describe('emitted', () => {
     expect(wrapper.emitted().hello[1]).toEqual(['foo', 'bar'])
   })
 
-  it.only('works with context.emit', () => {
+  // NOTE: This will fail until alpha 5.
+  // For now I am testing this by hacking node_modules/vue/dist/vue.esm.js with the following fix:
+  // https://github.com/vuejs/vue-next/commit/e308ad99e9f5bdfb0910a2d6959e746f558714c5
+  it('captures events emitted via ctx.emit', () => {
     const Component = defineComponent({
       name: 'ContextEmit',
 
@@ -35,8 +40,10 @@ describe('emitted', () => {
         )
       }
     })
-
     const wrapper = mount(Component)
+    expect(wrapper.emitted()).toEqual({})
+    expect(wrapper.emitted().hello).toEqual(undefined)
+
     wrapper.find('button').trigger('click')
     expect(wrapper.emitted().hello[0]).toEqual(['foo', 'bar'])
 

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,13 @@
+const originalConsole = console.info
+
+console.info = (...args) => {
+  if (
+    typeof args[0] === 'string' &&
+    args[0] &&
+    args[0].includes('Make sure to use the production build')
+  ) {
+    return
+  }
+
+  originalConsole(...args)
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     "baseUrl": ".",
     "paths": {
       "vue": [
-        "node_modules/vue/dist/vue.esm.prod.js"
+        "node_modules/vue/dist/vue.esm.js"
       ]
     }
   },


### PR DESCRIPTION
I am exploring some ideas for VTU and Vue.js 3 in this repo. This PR is related to the  `emitted` feature we have in Vue Test Utils. 

I am able to override `this.$emit` using `getCurrentInstance`, so when calling `this.$emit` I can capture the events in the same way VTU [current does is](https://github.com/vuejs/vue-test-utils/blob/dev/packages/create-instance/log-events.js). 

Because we do `freeze` [here](https://github.com/vuejs/vue-next/blob/8b2d6a35d053a7bef6c34dacde2693a41a41658e/packages/runtime-core/src/component.ts#L498), however, we cannot use a similar technique for overriding `context.emit` in `setup`.

Ideas:
- don't do freeze at all
- don't do freeze in __TEST__ as well as __DEV__
- an entirely different solution (cannot think of any right now)